### PR TITLE
add base requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django <= 5.1.0
+django-guid
+black
+flake8
+


### PR DESCRIPTION
adding in a few basic ones we can use, locked us below django 5.1 just in case we start using things and 5.1 causes a breakage etc. 

`django-guid` will help with log debugging 
`black` python formatter
`flake8` opinionated pythonic linter based on pep8. 